### PR TITLE
fix: redirect tracing logs from stdout to stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,9 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize tracing
-    tracing_subscriber::fmt::init();
+    // Initialize tracing. Write to stderr: stdout is reserved for the MCP JSON-RPC
+    // stream, and log lines on stdout corrupt the protocol.
+    tracing_subscriber::fmt().with_writer(std::io::stderr).init();
 
     // Parse CLI arguments
     let cli = Cli::parse();


### PR DESCRIPTION
## Problem

`tracing_subscriber::fmt::init()` writes logs to stdout by default. When `project-rag serve` runs as an MCP stdio server, stdout is exclusively used for the JSON-RPC message stream. Log lines on stdout are not valid JSON-RPC and cause parse errors on the client side (e.g. `JSONRPCMessage` validation failures in Python MCP clients), making tool calls silently return empty results.

## Fix

Redirect tracing output to stderr with `.with_writer(std::io::stderr)`. Logs remain visible in the terminal without interfering with the MCP protocol stream.

## Test plan

- [ ] Start `project-rag serve` with `RUST_LOG=info` and confirm log lines appear on stderr, not stdout
- [ ] Connect an MCP client and confirm tool calls return results normally